### PR TITLE
eth/tracers: add txHash field on txTraceResult

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -189,6 +189,7 @@ type txTraceContext struct {
 
 // txTraceResult is the result of a single transaction trace.
 type txTraceResult struct {
+	TxHash common.Hash `json:"txHash"`           // transaction hash
 	Result interface{} `json:"result,omitempty"` // Trace results produced by the tracer
 	Error  string      `json:"error,omitempty"`  // Trace failure produced by the tracer
 }
@@ -281,13 +282,13 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 					}
 					res, err := api.traceTx(localctx, msg, txctx, blockCtx, task.statedb, config)
 					if err != nil {
-						task.results[i] = &txTraceResult{Error: err.Error()}
+						task.results[i] = &txTraceResult{TxHash: tx.Hash(), Error: err.Error()}
 						log.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
 						break
 					}
 					// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
 					task.statedb.Finalise(api.backend.ChainConfig().IsEIP158(task.block.Number()))
-					task.results[i] = &txTraceResult{Result: res}
+					task.results[i] = &txTraceResult{TxHash: tx.Hash(), Result: res}
 				}
 				// Stream the result back to the user or abort on teardown
 				select {
@@ -533,10 +534,10 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 				}
 				res, err := api.traceTx(ctx, msg, txctx, blockCtx, task.statedb, config)
 				if err != nil {
-					results[task.index] = &txTraceResult{Error: err.Error()}
+					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
 					continue
 				}
-				results[task.index] = &txTraceResult{Result: res}
+				results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Result: res}
 			}
 		})
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -493,12 +493,14 @@ func TestTraceBlock(t *testing.T) {
 	}}
 	genBlocks := 10
 	signer := types.HomesteadSigner{}
+	var txHash common.Hash
 	api := NewAPI(newTestBackend(t, genBlocks, genesis, func(i int, b *core.BlockGen) {
 		// Transfer from account[0] to account[1]
 		//    value: 1000 wei
 		//    fee:   0 wei
 		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, big.NewInt(0), nil), signer, accounts[0].key)
 		b.AddTx(tx)
+		txHash = tx.Hash()
 	}))
 
 	var testSuite = []struct {
@@ -521,6 +523,7 @@ func TestTraceBlock(t *testing.T) {
 			expectErr:   nil,
 			expect: []*txTraceResult{
 				{
+					TxHash: txHash,
 					Result: &ethapi.ExecutionResult{
 						Gas:         params.TxGas,
 						Failed:      false,
@@ -544,6 +547,7 @@ func TestTraceBlock(t *testing.T) {
 			expectErr:   nil,
 			expect: []*txTraceResult{
 				{
+					TxHash: txHash,
 					Result: &ethapi.ExecutionResult{
 						Gas:         params.TxGas,
 						Failed:      false,
@@ -560,6 +564,7 @@ func TestTraceBlock(t *testing.T) {
 			expectErr:   nil,
 			expect: []*txTraceResult{
 				{
+					TxHash: txHash,
 					Result: &ethapi.ExecutionResult{
 						Gas:         params.TxGas,
 						Failed:      false,


### PR DESCRIPTION
modifies the interface for the results of `debug_traceBlock` and `debug_traceCall` by adding the `txHash`, allowing users to identify which transaction's trace result corresponds to. 