### PR TITLE
metrics: improve accuracy of CPU gauges

### DIFF
--- a/metrics/cpu.go
+++ b/metrics/cpu.go
@@ -18,7 +18,7 @@ package metrics
 
 // CPUStats is the system and process CPU stats.
 type CPUStats struct {
-	GlobalTime int64 // Time spent by the CPU working on all processes
-	GlobalWait int64 // Time spent by waiting on disk for all processes
-	LocalTime  int64 // Time spent by the CPU working on this process
+	GlobalTime float64 // Time spent by the CPU working on all processes
+	GlobalWait float64 // Time spent by waiting on disk for all processes
+	LocalTime  float64 // Time spent by the CPU working on this process
 }

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build !ios
 // +build !ios
 
 package metrics
@@ -37,7 +38,7 @@ func ReadCPUStats(stats *CPUStats) {
 	}
 	// requesting all cpu times will always return an array with only one time stats entry
 	timeStat := timeStats[0]
-	stats.GlobalTime = int64((timeStat.User + timeStat.Nice + timeStat.System) * cpu.ClocksPerSec)
-	stats.GlobalWait = int64((timeStat.Iowait) * cpu.ClocksPerSec)
+	stats.GlobalTime = timeStat.User + timeStat.Nice + timeStat.System
+	stats.GlobalWait = timeStat.Iowait
 	stats.LocalTime = getProcessCPUTime()
 }

--- a/metrics/cpu_syscall.go
+++ b/metrics/cpu_syscall.go
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build !windows
 // +build !windows
 
 package metrics
@@ -25,11 +26,11 @@ import (
 )
 
 // getProcessCPUTime retrieves the process' CPU time since program startup.
-func getProcessCPUTime() int64 {
+func getProcessCPUTime() float64 {
 	var usage syscall.Rusage
 	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil {
 		log.Warn("Failed to retrieve CPU time", "err", err)
 		return 0
 	}
-	return int64(usage.Utime.Sec+usage.Stime.Sec)*100 + int64(usage.Utime.Usec+usage.Stime.Usec)/10000 //nolint:unconvert
+	return float64(usage.Utime.Sec+usage.Stime.Sec) + float64(usage.Utime.Usec+usage.Stime.Usec)/1000000 //nolint:unconvert
 }

--- a/metrics/cpu_windows.go
+++ b/metrics/cpu_windows.go
@@ -18,6 +18,6 @@ package metrics
 
 // getProcessCPUTime returns 0 on Windows as there is no system call to resolve
 // the actual process' CPU time.
-func getProcessCPUTime() int64 {
+func getProcessCPUTime() float64 {
 	return 0
 }


### PR DESCRIPTION
This changes metrics collection to actually measure the time interval between collections, rather than assume 3 seconds. I did some ad hoc profiling, and on slower hardware (eg, my Raspberry Pi 4) I routinely saw intervals between 3.3 - 3.5 seconds, with some being as high as 4.5 seconds. This will generally cause the CPU gauge readings to be too high, and in some cases can cause impossibly large values for the CPU load metrics (eg. greater than 400 for a 4 core CPU).

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
