### PR TITLE
tests/fuzzers/rlp: avoid very large input

### DIFF
--- a/tests/fuzzers/rlp/rlp_fuzzer.go
+++ b/tests/fuzzers/rlp/rlp_fuzzer.go
@@ -40,7 +40,9 @@ func Fuzz(input []byte) int {
 	if len(input) == 0 {
 		return 0
 	}
-
+	if len(input) > 500*1024 {
+		return 0
+	}
 	var i int
 	{
 		rlp.Split(input)


### PR DESCRIPTION
The oss-fuzz engine crashes due to stack overflow decoding a large nested structure into a interface{}. This PR limits the size of the input data, so should avoid such crashes.

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
